### PR TITLE
Fix: Set editor height when editor only is selected

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -119,7 +119,7 @@
                      x-cloak
                      wire:ignore>
                     <div x-ref="editor" class="w-full ace_editor"
-                         style="min-height: 30vh;height:300px"></div>
+                         style="min-height: 30vh;height:{{ $getEditorHeight() }}"></div>
                 </div>
             </div>
     @elseif($getMode() === 'viewer')


### PR DESCRIPTION
- Now is possible to set the editor height when editor only mode is selected.