### PR TITLE
Added Height Control for Viewer Mode

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -127,7 +127,7 @@
                 </div>
             </div>
     @elseif($getViewerMode())
-            <div style="font-size: 0.875rem; line-height: 1.25rem;">
+            <div style="font-size: 0.875rem; line-height: 1.25rem;min-height: 30vh;height:{{ $getEditorHeight() }};overflow: auto;">
                 <pre class="prettyjson" x-html="prettyJson"></pre>
             </div>
     @endif

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -22,6 +22,14 @@
                        },
                        display: 'viewer'
                     }"
+        x-load-css="[
+            @js(\Filament\Support\Facades\FilamentAsset::getStyleHref('app')),
+            @js(\Filament\Support\Facades\FilamentAsset::getStyleHref('jsoneditor-css-cdn'))
+        ]"
+        x-load-js="[
+            @js(\Filament\Support\Facades\FilamentAsset::getScriptSrc('app')),
+            @js(\Filament\Support\Facades\FilamentAsset::getScriptSrc('jsoneditor-js-cdn'))
+        ]"
     >
     @if(! $getEditorMode() && ! $getViewerMode())
             <div class="container">

--- a/src/FilamentJsonColumnServiceProvider.php
+++ b/src/FilamentJsonColumnServiceProvider.php
@@ -28,10 +28,10 @@ class FilamentJsonColumnServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         FilamentAsset::register([
-            Js::make('jsoneditor-js-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/10.0.2/jsoneditor.min.js'),
-            Js::make('app', __DIR__ . '/../resources/js/app.js'),
-            Css::make('app', __DIR__ . '/../resources/css/app.css'),
-            Css::make('jsoneditor-css-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/10.0.2/jsoneditor.min.css'),
+            Js::make('jsoneditor-js-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/10.0.2/jsoneditor.min.js')->loadedOnRequest(),
+            Js::make('app', __DIR__ . '/../resources/js/app.js')->loadedOnRequest(),
+            Css::make('app', __DIR__ . '/../resources/css/app.css')->loadedOnRequest(),
+            Css::make('jsoneditor-css-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/10.0.2/jsoneditor.min.css')->loadedOnRequest(),
         ]);
     }
 }


### PR DESCRIPTION
This PR introduces height control for the getViewerMode in the editor component. A dynamic height is applied using the $getEditorHeight() function, allowing for more flexible and responsive design.  