### PR TITLE
Fix: don't force the conversion of state data to an object.

### DIFF
--- a/src/JsonColumn.php
+++ b/src/JsonColumn.php
@@ -39,7 +39,7 @@ class JsonColumn extends Field
 
         $this->afterStateHydrated(function (JsonColumn $component, $state) {
             if (is_array($state)) {
-                $component->state(json_encode($state, JSON_FORCE_OBJECT));
+                $component->state(json_encode($state));
             }
         });
 


### PR DESCRIPTION
This line is silently but effectively mutating the stored data in the database.

Stored data as:

`[
 "First",
 "Second"
]`

will be transformed into:

`{
 "0" : "First",
 "1": "Second"
}`

which in some cases cases will not matter, but in others will result in unexpected consequences.