### PR TITLE
Add translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ JsonColumn::make('example')->modes(array|Closure ['code', 'text', 'tree']);
 
 Values are validated as proper JSON by default.
 
+## Translations
+
+The `Viewer` and `Editor` tab labels are translatable. Publish the translation files to customize them or add your own locale:
+
+```bash
+php artisan vendor:publish --tag="filament-json-column-translations"
+```
+
+This copies the files to `lang/vendor/filament-json-column/{locale}/json-column.php`. The displayed language follows your application's locale.
+
 ## Credits
 I've taken inspiration from the following plugins: [Pretty JSON](https://github.com/novadaemon/filament-pretty-json) & [JSONeditor](https://github.com/invaders-xx/filament-jsoneditor).
 

--- a/resources/lang/en/json-column.php
+++ b/resources/lang/en/json-column.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'viewer' => 'Viewer',
+    'editor' => 'Editor',
+];

--- a/resources/views/components/json-toggle.blade.php
+++ b/resources/views/components/json-toggle.blade.php
@@ -16,7 +16,7 @@
                     'active': display === 'viewer',
                  }"
             >
-                <div>Viewer</div>
+                <div>{{ __('filament-json-column::json-column.viewer') }}</div>
             </div>
             <div class="control"
                  x-on:click="!jsonError && (display = 'editor')"
@@ -24,7 +24,7 @@
                     'active': display === 'editor',
                  }"
             >
-                <div>Editor</div>
+                <div>{{ __('filament-json-column::json-column.editor') }}</div>
             </div>
         </div>
     </div>

--- a/src/FilamentJsonColumnServiceProvider.php
+++ b/src/FilamentJsonColumnServiceProvider.php
@@ -22,7 +22,8 @@ class FilamentJsonColumnServiceProvider extends PackageServiceProvider
          * More info: https://github.com/spatie/laravel-package-tools
          */
         $package->name(static::$name)
-            ->hasViews();
+            ->hasViews()
+            ->hasTranslations();
     }
 
     public function packageBooted(): void

--- a/tests/Feature/JsonColumnTest.php
+++ b/tests/Feature/JsonColumnTest.php
@@ -113,3 +113,23 @@ it('does not show toggle on editor or viewer mode', function () {
     ])
         ->assertDontSee('toggle-component');
 });
+
+it('renders the default english toggle labels', function () {
+    Livewire::test(FormTestComponent::class)
+        ->assertSee('Viewer')
+        ->assertSee('Editor');
+});
+
+it('translates the toggle labels for the active locale', function () {
+    app('translator')->addLines([
+        'json-column.viewer' => 'Mirador',
+        'json-column.editor' => 'Redactor',
+    ], 'xx', 'filament-json-column');
+
+    app()->setLocale('xx');
+
+    Livewire::test(FormTestComponent::class)
+        ->assertSee('Mirador')
+        ->assertSee('Redactor')
+        ->assertDontSee('Viewer');
+});


### PR DESCRIPTION
## Summary

Makes the **Viewer** / **Editor** tab labels translatable so the component respects the application locale (the only user-facing strings in the package; the validation message already uses Laravel's `validation.json` key).

## Changes
- Register package translations via spatie's `hasTranslations()`.
- Add the canonical English lang file at `resources/lang/en/json-column.php`.
- The toggle view now renders the labels through `__('filament-json-column::json-column.{viewer,editor}')`.
- Two tests: default English labels render, and a custom locale's translations are used.
- README: a short Translations section.

## Overriding / adding locales
```bash
php artisan vendor:publish --tag="filament-json-column-translations"
```
Copies the files to `lang/vendor/filament-json-column/{locale}/json-column.php`.

## Validation
- Full suite (14 tests) passes on PHP 8.2–8.4 / Laravel 11–12.
- Verified end-to-end in a real Filament 5 app with `APP_LOCALE=fr`: the tabs render as **Visionneuse** / **Éditeur**.